### PR TITLE
add check against running clear save sector from ROM

### DIFF
--- a/src/gt/persist.c
+++ b/src/gt/persist.c
@@ -3,10 +3,21 @@
 #include "drawing_funcs.h"
 #include "persist.h"
 
+char executing_from_rom() {
+    asm("PLX");
+    asm("PLA");
+    asm("PHA");
+    asm("PHX");
+    return __A__ > 0xC0;
+}
+
 #pragma code-name (push, "DATA")
 #pragma optimize (push, on)
 char i, k;
 void clear_save_sector() {
+    if(executing_from_rom()) {
+        while(1) {}
+    }
     *dma_flags = flagsMirror & ~(DMA_IRQ | DMA_NMI);
     asm("SEI");
     change_rom_bank(SAVE_BANK_NUM);


### PR DESCRIPTION
ported the fix over from SDK mainline

there is a chance that clear_save_sector() can accidentally get run from ROM such as during a cold boot if the program counter is randomized.

the probability is increased by the function's location in the DATA segment because the initialized data mostly does not contain functions and if the program counter ends up somewhere in DATA it might keep executing until it reaches the clear_save_sector() function. so adding the execution check greatly decreases the chance of this happening randomly, because it is overwhelmingly more likely for the PC to end up at area before the function than it is for it to randomly end up on the exact instruction the function starts